### PR TITLE
iqe_import: animation improvements

### DIFF
--- a/iqe_import.py
+++ b/iqe_import.py
@@ -497,18 +497,25 @@ def make_anim(iqmodel, anim, amtobj, bone_axis):
 	print("importing animation %s with %d frames" % (anim.name, len(anim.frames)))
 	action = bpy.data.actions.new(anim.name)
 	action.id_root = 'OBJECT'
-	action.use_fake_user = True
 	amtobj.animation_data.action = action
 	fps = bpy.context.scene.render.fps / anim.framerate
 	for n in range(len(anim.frames)):
 		make_pose(iqmodel, anim.frames[n], amtobj, bone_axis, fps * n)
+	amtobj.animation_data.action = None
 	return action
 
 def make_actions(iqmodel, amtobj, bone_axis):
 	bpy.context.scene.frame_start = 0
 	amtobj.animation_data_create()
+	nla_track = amtobj.animation_data.nla_tracks.new()
+	nla_track.name = iqmodel.name
+	t = 0
 	for anim in iqmodel.anims:
 		action = make_anim(iqmodel, anim, amtobj, bone_axis)
+		strip = nla_track.strips.new(anim.name, t, action)
+		if anim.loop:
+			strip.repeat = 2
+		t = strip.frame_end
 
 #
 # Create simple material by looking at the magic words.

--- a/iqe_import.py
+++ b/iqe_import.py
@@ -73,7 +73,7 @@ class IQPose:
 class IQAnimation:
 	def __init__(self, name):
 		self.name = name
-		self.framerate = 30
+		self.framerate = bpy.context.scene.render.fps
 		self.loop = False
 		self.frames = []
 
@@ -499,8 +499,9 @@ def make_anim(iqmodel, anim, amtobj, bone_axis):
 	action.id_root = 'OBJECT'
 	action.use_fake_user = True
 	amtobj.animation_data.action = action
+	fps = bpy.context.scene.render.fps / anim.framerate
 	for n in range(len(anim.frames)):
-		make_pose(iqmodel, anim.frames[n], amtobj, bone_axis, n)
+		make_pose(iqmodel, anim.frames[n], amtobj, bone_axis, fps * n)
 	return action
 
 def make_actions(iqmodel, amtobj, bone_axis):


### PR DESCRIPTION
* Setting the head/tail/roll is simpler and more correct. [Here](https://github.com/ccxvii/asstools/files/2907220/walk.zip) is an example IQE that shows the difference; the animation was different between `./iqeview` and Blender. This is fixed now.
* Animation framerate is taken into account.
* The action for each animation is pushed to the armature's NLA tracks. This removes the need to add a fake user.

    There are basically two ways to do this. When there is one animation, they are the same.

    ### All in one track (horizontally)

    ![horizontal](https://user-images.githubusercontent.com/11024420/53442096-103d2680-39ce-11e9-9e7f-8d1c1ce38fa9.png)

    \+ You can view all animations by just scrubbing the timeline.

    ### Each in its own track (vertically)

    ![vertical](https://user-images.githubusercontent.com/11024420/53442105-13d0ad80-39ce-11e9-8573-49566fcfbcb0.png)

    \+ The glTF exporter expects this format. The [EXM](https://github.com/excessive/iqm-exm) exporter formerly expected this format, but I asked and its now okay with either option, haha.
    \+ Easier to edit the actions maybe?

----

I opted for the former, putting them all in one track, since I like that it makes it easy to see all the animations. What do you think? If you have an opinion on this, I can easily change it.





    
